### PR TITLE
feat: add flat-file persistence for all app data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bin/
 
 /text-ui-test/ACTUAL.TXT
 text-ui-test/EXPECTED-UNIX.TXT
+
+/data/

--- a/src/main/java/ccamanager/CcaLedger.java
+++ b/src/main/java/ccamanager/CcaLedger.java
@@ -5,46 +5,73 @@ import ccamanager.manager.CcaManager;
 import ccamanager.manager.EventManager;
 import ccamanager.manager.ResidentManager;
 import ccamanager.parser.Parser;
+import ccamanager.storage.StorageManager;
 import ccamanager.ui.Ui;
+
+import java.io.IOException;
 
 /**
  * CcaLedger — the orchestrator of the application.
  * <p>
  * Responsibilities:
  * - Owns the main run loop
- * - Wires together Parser, Ui, CcaManager, ResidentManager
+ * - Wires together Parser, Ui, CcaManager, ResidentManager, EventManager, StorageManager
  * - Calls Parser to get a Command, then calls command.execute()
+ * - Saves to disk after every mutating command
  * <p>
  * DO NOT add business logic here. This class only coordinates.
  */
 public class CcaLedger {
 
-    private final CcaManager ccaManager;
+    private final CcaManager      ccaManager;
     private final ResidentManager residentManager;
-    private final EventManager eventManager;
-    private final Ui ui;
-    private final Parser parser;
+    private final EventManager    eventManager;
+    private final Ui              ui;
+    private final Parser          parser;
+    private final StorageManager  storage;
 
     public CcaLedger() {
-        this.ccaManager = new CcaManager();
+        this.ccaManager      = new CcaManager();
         this.residentManager = new ResidentManager();
-        this.eventManager = new EventManager();
-        this.ui = new Ui();
-        this.parser = new Parser();
+        this.eventManager    = new EventManager();
+        this.ui              = new Ui();
+        this.parser          = new Parser();
+        this.storage         = new StorageManager();
     }
 
     /**
      * Starts the application loop.
-     * Reads input → parses to Command → executes → repeats until exit.
+     * Loads saved data → shows welcome → reads input → parses → executes →
+     * saves (if mutating) → repeats until exit.
      */
     public void run() {
+        // Restore persisted state before showing the welcome screen.
+        // A missing data directory (first run) is handled gracefully inside load().
+        try {
+            storage.load(ccaManager, residentManager, eventManager);
+        } catch (IOException e) {
+            ui.showError("Failed to load saved data: " + e.getMessage()
+                    + " — starting with empty state.");
+        }
+
         ui.showWelcome();
         boolean isRunning = true;
 
         while (isRunning) {
-            String input = ui.readInput();
+            String  input   = ui.readInput();
             Command command = parser.parse(input);
             command.execute(ccaManager, residentManager, eventManager, ui);
+
+            // Only write to disk when something could have changed.
+            // View/stats commands override isReadOnly() to return true.
+            if (!command.isReadOnly()) {
+                try {
+                    storage.save(ccaManager, residentManager, eventManager);
+                } catch (IOException e) {
+                    ui.showError("Failed to save data: " + e.getMessage());
+                }
+            }
+
             isRunning = !command.isExit();
         }
 

--- a/src/main/java/ccamanager/Main.java
+++ b/src/main/java/ccamanager/Main.java
@@ -10,7 +10,7 @@ public class Main {
 
     public static void main(String[] args) {
         LogManager.getLogManager().reset();
-        assert false : "dummy assertion set to fail";
+        // assert false : "dummy assertion set to fail";
         new CcaLedger().run();
     }
 }

--- a/src/main/java/ccamanager/command/CcaStatsCommand.java
+++ b/src/main/java/ccamanager/command/CcaStatsCommand.java
@@ -99,4 +99,9 @@ public class CcaStatsCommand extends Command {
         }
         return mostActiveResidents;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/Command.java
+++ b/src/main/java/ccamanager/command/Command.java
@@ -5,7 +5,13 @@ import ccamanager.manager.EventManager;
 import ccamanager.manager.ResidentManager;
 import ccamanager.ui.Ui;
 
-
+/**
+ * Base class for all commands.
+ * <p>
+ * Subclasses implement execute() with their specific logic.
+ * View/stats commands should also override isReadOnly() to return true
+ * so CcaLedger skips the save step after they run.
+ */
 public abstract class Command {
 
     /**
@@ -14,6 +20,7 @@ public abstract class Command {
      *
      * @param ccaManager      manages the list of CCAs
      * @param residentManager manages the list of Residents
+     * @param eventManager    manages the list of Events
      * @param ui              used to display output — ONLY class that should print
      */
     public abstract void execute(CcaManager ccaManager, ResidentManager residentManager,
@@ -22,11 +29,22 @@ public abstract class Command {
     /**
      * Returns true if this command should end the application loop.
      * Only ExitCommand should override this to return true.
-     *
-     * @return false by default
      */
     public boolean isExit() {
         return false;
     }
-}
 
+    /**
+     * Returns true if this command does not mutate any data.
+     * CcaLedger uses this to skip the save step after read-only commands,
+     * avoiding unnecessary disk writes.
+     * <p>
+     * Override to return true in:
+     *   ViewCcaCommand, ViewResidentCommand, ViewCcaExco, ViewCcaEvents,
+     *   ViewMyEvents, ViewPointsCommand, CcaStatsCommand, ResidentStatsCommand,
+     *   HelpCommand, UnknownCommand
+     */
+    public boolean isReadOnly() {
+        return false;
+    }
+}

--- a/src/main/java/ccamanager/command/HelpCommand.java
+++ b/src/main/java/ccamanager/command/HelpCommand.java
@@ -25,4 +25,9 @@ public class HelpCommand extends Command {
                 "> bye";
         ui.showMessage(help);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/ResidentStatsCommand.java
+++ b/src/main/java/ccamanager/command/ResidentStatsCommand.java
@@ -62,4 +62,9 @@ public class ResidentStatsCommand extends Command {
         }
         return mostActiveResidents;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/UnknownCommand.java
+++ b/src/main/java/ccamanager/command/UnknownCommand.java
@@ -24,5 +24,10 @@ public class UnknownCommand extends Command {
     public void execute(CcaManager ccaManager, ResidentManager residentManager, EventManager eventManager, Ui ui) {
         ui.showError(message);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }
 

--- a/src/main/java/ccamanager/command/ViewCcaCommand.java
+++ b/src/main/java/ccamanager/command/ViewCcaCommand.java
@@ -21,5 +21,10 @@ public class ViewCcaCommand extends Command {
         ArrayList<Cca> ccaList = ccaManager.getCCAList();
         ui.showCcaList(ccaList);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }
 

--- a/src/main/java/ccamanager/command/ViewCcaEvents.java
+++ b/src/main/java/ccamanager/command/ViewCcaEvents.java
@@ -24,4 +24,9 @@ public class ViewCcaEvents extends Command{
         ArrayList <Event> ccaEvents = eventManager.viewCcaEvents(ccaName);
         ui.viewMatchingCcas(ccaEvents);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/ViewCcaExco.java
+++ b/src/main/java/ccamanager/command/ViewCcaExco.java
@@ -36,4 +36,9 @@ public class ViewCcaExco extends Command {
             ui.showError(e.getMessage());
         }
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/ViewMyEvents.java
+++ b/src/main/java/ccamanager/command/ViewMyEvents.java
@@ -25,4 +25,9 @@ public class ViewMyEvents extends Command {
         System.out.println("Hi "+ resident.getName()+", here are your events: ");
         ui.viewMyCcas(ccaEvents);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ccamanager/command/ViewPointsCommand.java
+++ b/src/main/java/ccamanager/command/ViewPointsCommand.java
@@ -15,5 +15,10 @@ public class ViewPointsCommand extends Command{
         ArrayList<Resident> residentList = residentManager.getResidentList();
         ui.showCcaPoints(residentList);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }
 

--- a/src/main/java/ccamanager/command/ViewResidentCommand.java
+++ b/src/main/java/ccamanager/command/ViewResidentCommand.java
@@ -25,5 +25,10 @@ public class ViewResidentCommand extends Command {
         ArrayList<Resident> residentList = residentManager.getResidentList();
         ui.showResidentList(residentList);
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }
 

--- a/src/main/java/ccamanager/manager/CcaManager.java
+++ b/src/main/java/ccamanager/manager/CcaManager.java
@@ -80,4 +80,10 @@ public class CcaManager {
         logger.log(Level.WARNING, "Failed to delete CCA: {0}. (Not an exisitng CCA).", ccaName);
         throw new CcaNotFoundException("The CCA " + ccaName + " does not exist, please enter a valid CCA name.");
     }
+
+    public Cca findByName(String name) {
+        return ccaList.stream()
+                .filter(c -> c.getName().equalsIgnoreCase(name))
+                .findFirst().orElse(null);
+    }
 }

--- a/src/main/java/ccamanager/manager/EventManager.java
+++ b/src/main/java/ccamanager/manager/EventManager.java
@@ -89,6 +89,11 @@ public class EventManager {
         return matchingEvents;
     }
 
-
+    public Event findByNameAndCca(String eventName, String ccaName) {
+        return events.stream()
+                .filter(e -> e.getEventName().equalsIgnoreCase(eventName)
+                        && e.getCca().getName().equalsIgnoreCase(ccaName))
+                .findFirst().orElse(null);
+    }
 }
 

--- a/src/main/java/ccamanager/manager/ResidentManager.java
+++ b/src/main/java/ccamanager/manager/ResidentManager.java
@@ -92,4 +92,10 @@ public class ResidentManager {
         logger.log(Level.WARNING, "Failed to delete resident: {0}. (Not an exisitng resident).", residentName);
         throw new ResidentNotFoundException(residentName + " does not exist, please enter a valid CCA name.");
     }
+
+    public Resident findByMatric(String matric) {
+        return residents.stream()
+                .filter(r -> r.getMatricNumber().equalsIgnoreCase(matric))
+                .findFirst().orElse(null);
+    }
 }

--- a/src/main/java/ccamanager/storage/StorageManager.java
+++ b/src/main/java/ccamanager/storage/StorageManager.java
@@ -1,0 +1,450 @@
+package ccamanager.storage;
+
+import ccamanager.enumerations.CcaLevel;
+import ccamanager.exceptions.DuplicateCcaException;
+import ccamanager.exceptions.DuplicateEventException;
+import ccamanager.exceptions.DuplicateResidentException;
+import ccamanager.exceptions.InvalidCcaLevelException;
+import ccamanager.exceptions.ResidentAlreadyInCcaException;
+import ccamanager.manager.CcaManager;
+import ccamanager.manager.EventManager;
+import ccamanager.manager.ResidentManager;
+import ccamanager.model.Cca;
+import ccamanager.model.Event;
+import ccamanager.model.Resident;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * StorageManager — handles all reading and writing of persistent data to text files.
+ * <p>
+ * File layout:
+ *   data/ccas.txt               — one CCA per line
+ *   data/residents.txt          — one resident per line
+ *   data/events.txt             — one event per line
+ *   data/memberships.txt        — Resident <-> CCA join table (points + isExco flag)
+ *   data/event_attendance.txt   — Resident <-> Event join table
+ * <p>
+ * Column separator: pipe ( | ). Literal pipes inside values are escaped as \|
+ * Literal backslashes are escaped as \\ so the two never interfere.
+ * <p>
+ * Load order is critical — see load() for explanation.
+ */
+public class StorageManager {
+
+    private static final Logger LOGGER = Logger.getLogger(StorageManager.class.getName());
+
+    private static final String DATA_DIR        = "data";
+    private static final String CCA_FILE        = DATA_DIR + "/ccas.txt";
+    private static final String RESIDENT_FILE   = DATA_DIR + "/residents.txt";
+    private static final String EVENT_FILE      = DATA_DIR + "/events.txt";
+    private static final String MEMBER_FILE     = DATA_DIR + "/memberships.txt";
+    private static final String ATTENDANCE_FILE = DATA_DIR + "/event_attendance.txt";
+
+    private static final String SEP       = "|";
+    private static final String SEP_REGEX = "\\|";
+
+    // =========================================================================
+    // SAVE — full snapshot on every call, overwrites existing files
+    // =========================================================================
+
+    /**
+     * Persists all in-memory state to disk. Overwrites existing files completely.
+     * Should be called by CcaLedger after every mutating command.
+     */
+    public void save(CcaManager ccaManager,
+                     ResidentManager residentManager,
+                     EventManager eventManager) throws IOException {
+        ensureDataDir();
+        saveCcas(ccaManager);
+        saveResidents(residentManager);
+        saveEvents(eventManager);
+        saveMemberships(residentManager);
+        saveEventAttendance(eventManager);
+    }
+
+    /**
+     * Writes ccas.txt
+     * Format: name|level
+     * Example: Basketball|HIGH
+     */
+    private void saveCcas(CcaManager cm) throws IOException {
+        try (BufferedWriter w = openWriter(CCA_FILE)) {
+            for (Cca cca : cm.getCCAList()) {
+                w.write(escape(cca.getName()) + SEP + cca.getLevel().name());
+                w.newLine();
+            }
+        }
+    }
+
+    /**
+     * Writes residents.txt
+     * Format: name|matricNumber
+     * Example: Alice Tan|A1234567X
+     */
+    private void saveResidents(ResidentManager rm) throws IOException {
+        try (BufferedWriter w = openWriter(RESIDENT_FILE)) {
+            for (Resident r : rm.getResidentList()) {
+                w.write(escape(r.getName()) + SEP + escape(r.getMatricNumber()));
+                w.newLine();
+            }
+        }
+    }
+
+    /**
+     * Writes events.txt
+     * Format: eventName|ccaName|eventDate
+     * Example: AGM|Basketball|2025-04-01
+     */
+    private void saveEvents(EventManager em) throws IOException {
+        try (BufferedWriter w = openWriter(EVENT_FILE)) {
+            for (Event e : em.getEventList()) {
+                w.write(escape(e.getEventName()) + SEP
+                        + escape(e.getCca().getName()) + SEP
+                        + escape(e.getEventDate()));
+                w.newLine();
+            }
+        }
+    }
+
+    /**
+     * Writes memberships.txt — the Resident <-> CCA join table.
+     * Format: matricNumber|ccaName|points|isExco
+     * Example: A1234567X|Basketball|50|false
+     * <p>
+     * We iterate residents so each resident's per-CCA point value is
+     * naturally available from resident.getPoints(). The isExco flag
+     * is resolved by checking whether the resident appears in cca.getExcos().
+     */
+    private void saveMemberships(ResidentManager rm) throws IOException {
+        try (BufferedWriter w = openWriter(MEMBER_FILE)) {
+            for (Resident r : rm.getResidentList()) {
+                for (int i = 0; i < r.getCcas().size(); i++) {
+                    Cca     cca    = r.getCcas().get(i);
+                    int     pts    = r.getPoints().get(i);
+                    boolean isExco = cca.getExcos().contains(r);
+                    w.write(escape(r.getMatricNumber()) + SEP
+                            + escape(cca.getName()) + SEP
+                            + pts + SEP
+                            + isExco);
+                    w.newLine();
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes event_attendance.txt — the Resident <-> Event join table.
+     * Format: matricNumber|eventName|ccaName
+     * Example: A1234567X|AGM|Basketball
+     * <p>
+     * ccaName is stored alongside eventName because event names are not
+     * guaranteed to be unique across different CCAs (both could have "AGM").
+     * Together they form a composite FK back to events.txt.
+     */
+    private void saveEventAttendance(EventManager em) throws IOException {
+        try (BufferedWriter w = openWriter(ATTENDANCE_FILE)) {
+            for (Event e : em.getEventList()) {
+                for (Resident r : e.getParticipants()) {
+                    w.write(escape(r.getMatricNumber()) + SEP
+                            + escape(e.getEventName()) + SEP
+                            + escape(e.getCca().getName()));
+                    w.newLine();
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // LOAD — reconstruct full in-memory state from disk
+    // =========================================================================
+
+    /**
+     * Loads all persisted data from disk into the managers.
+     * Safe to call on first run when no data files exist yet.
+     * <p>
+     * Order is critical because later files reference earlier ones as FKs:
+     *   1. ccas.txt          — no dependencies
+     *   2. residents.txt     — no dependencies
+     *   3. events.txt        — FK: ccaName → ccas.txt
+     *   4. memberships.txt   — FK: matricNumber → residents.txt, ccaName → ccas.txt
+     *   5. event_attendance  — FK: matricNumber → residents.txt,
+     *                              (eventName + ccaName) → events.txt
+     */
+    public void load(CcaManager ccaManager,
+                     ResidentManager residentManager,
+                     EventManager eventManager) throws IOException {
+        ensureDataDir();
+        loadCcas(ccaManager);
+        loadResidents(residentManager);
+        loadEvents(ccaManager, eventManager);
+        loadMemberships(ccaManager, residentManager);
+        loadEventAttendance(residentManager, eventManager);
+    }
+
+    /**
+     * Loads ccas.txt → populates CcaManager.
+     * Format: name|level
+     */
+    private void loadCcas(CcaManager cm) throws IOException {
+        Path p = Path.of(CCA_FILE);
+        if (!Files.exists(p)) {
+            return;
+        }
+        int lineNum = 0;
+        for (String line : Files.readAllLines(p)) {
+            lineNum++;
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] f = line.split(SEP_REGEX, 2);
+            if (f.length < 2) {
+                LOGGER.log(Level.WARNING, "ccas.txt line {0}: too few fields — skipping: {1}",
+                        new Object[]{lineNum, line});
+                continue;
+            }
+            CcaLevel level;
+            try {
+                level = CcaLevel.valueOf(f[1].trim());
+            } catch (IllegalArgumentException e) {
+                // Skip rather than load with UNKNOWN since addCCA rejects UNKNOWN anyway
+                LOGGER.log(Level.WARNING, "ccas.txt line {0}: unknown level ''{1}'' — skipping",
+                        new Object[]{lineNum, f[1].trim()});
+                continue;
+            }
+            try {
+                cm.addCCA(unescape(f[0]), level);
+            } catch (DuplicateCcaException | InvalidCcaLevelException e) {
+                LOGGER.log(Level.WARNING, "ccas.txt line {0}: could not add CCA — skipping: {1}",
+                        new Object[]{lineNum, e.getMessage()});
+            }
+        }
+    }
+
+    /**
+     * Loads residents.txt → populates ResidentManager.
+     * Format: name|matricNumber
+     */
+    private void loadResidents(ResidentManager rm) throws IOException {
+        Path p = Path.of(RESIDENT_FILE);
+        if (!Files.exists(p)) {
+            return;
+        }
+        int lineNum = 0;
+        for (String line : Files.readAllLines(p)) {
+            lineNum++;
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] f = line.split(SEP_REGEX, 2);
+            if (f.length < 2) {
+                LOGGER.log(Level.WARNING, "residents.txt line {0}: too few fields — skipping: {1}",
+                        new Object[]{lineNum, line});
+                continue;
+            }
+            try {
+                rm.addResident(unescape(f[0]), unescape(f[1]));
+            } catch (DuplicateResidentException e) {
+                LOGGER.log(Level.WARNING, "residents.txt line {0}: duplicate resident — skipping: {1}",
+                        new Object[]{lineNum, e.getMessage()});
+            }
+        }
+    }
+
+    /**
+     * Loads events.txt → populates EventManager.
+     * Format: eventName|ccaName|eventDate
+     * Rows whose CCA FK cannot be resolved are skipped with a warning.
+     */
+    private void loadEvents(CcaManager cm, EventManager em) throws IOException {
+        Path p = Path.of(EVENT_FILE);
+        if (!Files.exists(p)) {
+            return;
+        }
+        int lineNum = 0;
+        for (String line : Files.readAllLines(p)) {
+            lineNum++;
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] f = line.split(SEP_REGEX, 3);
+            if (f.length < 3) {
+                LOGGER.log(Level.WARNING, "events.txt line {0}: too few fields — skipping: {1}",
+                        new Object[]{lineNum, line});
+                continue;
+            }
+            Cca cca = cm.findByName(unescape(f[1]));
+            if (cca == null) {
+                LOGGER.log(Level.WARNING, "events.txt line {0}: unknown CCA ''{1}'' — skipping",
+                        new Object[]{lineNum, f[1]});
+                continue;
+            }
+            try {
+                em.addEvent(unescape(f[0]), cca, unescape(f[2]));
+            } catch (DuplicateEventException e) {
+                LOGGER.log(Level.WARNING, "events.txt line {0}: duplicate event — skipping: {1}",
+                        new Object[]{lineNum, e.getMessage()});
+            }
+        }
+    }
+
+    /**
+     * Loads memberships.txt → links Residents to CCAs with points and exco status.
+     * Format: matricNumber|ccaName|points|isExco
+     * <p>
+     * Uses Resident.addCcaToResident(cca, points) to populate the resident side,
+     * and Cca.addResidentToCca(resident) for the CCA side.
+     * For exco members, we add directly to the exco list to avoid
+     * double-registering them as regular members via addExcoToCca().
+     */
+    private void loadMemberships(CcaManager cm, ResidentManager rm) throws IOException {
+        Path p = Path.of(MEMBER_FILE);
+        if (!Files.exists(p)) {
+            return;
+        }
+        int lineNum = 0;
+        for (String line : Files.readAllLines(p)) {
+            lineNum++;
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] f = line.split(SEP_REGEX, 4);
+            if (f.length < 4) {
+                LOGGER.log(Level.WARNING, "memberships.txt line {0}: too few fields — skipping: {1}",
+                        new Object[]{lineNum, line});
+                continue;
+            }
+
+            Resident resident = rm.findByMatric(unescape(f[0]));
+            Cca      cca      = cm.findByName(unescape(f[1]));
+
+            if (resident == null) {
+                LOGGER.log(Level.WARNING, "memberships.txt line {0}: unknown matric ''{1}'' — skipping",
+                        new Object[]{lineNum, f[0]});
+                continue;
+            }
+            if (cca == null) {
+                LOGGER.log(Level.WARNING, "memberships.txt line {0}: unknown CCA ''{1}'' — skipping",
+                        new Object[]{lineNum, f[1]});
+                continue;
+            }
+
+            int points;
+            try {
+                points = Integer.parseInt(f[2].trim());
+            } catch (NumberFormatException e) {
+                LOGGER.log(Level.WARNING, "memberships.txt line {0}: invalid points ''{1}'' — skipping",
+                        new Object[]{lineNum, f[2]});
+                continue;
+            }
+
+            boolean isExco = Boolean.parseBoolean(f[3].trim());
+
+            // Populate the Resident side (parallel ccas + points lists)
+            resident.addCcaToResident(cca, points);
+
+            // Populate the CCA side
+            try {
+                if (isExco) {
+                    // Add to exco list directly, then register as member separately.
+                    // We cannot call addExcoToCca() here because it calls addResidentToCca()
+                    // internally, which would conflict with our explicit addResidentToCca() call
+                    // and throw a duplicate exception.
+                    cca.getExcos().add(resident);
+                    cca.addResidentToCca(resident);
+                } else {
+                    cca.addResidentToCca(resident);
+                }
+            } catch (ResidentAlreadyInCcaException e) {
+                LOGGER.log(Level.WARNING, "memberships.txt line {0}: duplicate membership — skipping: {1}",
+                        new Object[]{lineNum, e.getMessage()});
+            }
+        }
+    }
+
+    /**
+     * Loads event_attendance.txt → marks Residents as participants of Events.
+     * Format: matricNumber|eventName|ccaName
+     * <p>
+     * (eventName + ccaName) forms a composite FK that uniquely identifies an event
+     * because two CCAs may independently hold an event with the same name.
+     */
+    private void loadEventAttendance(ResidentManager rm, EventManager em) throws IOException {
+        Path p = Path.of(ATTENDANCE_FILE);
+        if (!Files.exists(p)) {
+            return;
+        }
+        int lineNum = 0;
+        for (String line : Files.readAllLines(p)) {
+            lineNum++;
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] f = line.split(SEP_REGEX, 3);
+            if (f.length < 3) {
+                LOGGER.log(Level.WARNING, "event_attendance.txt line {0}: too few fields — skipping: {1}",
+                        new Object[]{lineNum, line});
+                continue;
+            }
+
+            Resident resident = rm.findByMatric(unescape(f[0]));
+            Event    event    = em.findByNameAndCca(unescape(f[1]), unescape(f[2]));
+
+            if (resident == null) {
+                LOGGER.log(Level.WARNING,
+                        "event_attendance.txt line {0}: unknown matric ''{1}'' — skipping",
+                        new Object[]{lineNum, f[0]});
+                continue;
+            }
+            if (event == null) {
+                LOGGER.log(Level.WARNING,
+                        "event_attendance.txt line {0}: unknown event ''{1}'' in CCA ''{2}'' — skipping",
+                        new Object[]{lineNum, f[1], f[2]});
+                continue;
+            }
+
+            event.addResident(resident);
+        }
+    }
+
+    // =========================================================================
+    // HELPERS
+    // =========================================================================
+
+    private void ensureDataDir() throws IOException {
+        Files.createDirectories(Path.of(DATA_DIR));
+    }
+
+    /** Opens a writer that overwrites the file from scratch each time. */
+    private BufferedWriter openWriter(String path) throws IOException {
+        return new BufferedWriter(new FileWriter(path, false));
+    }
+
+    /**
+     * Escapes backslashes first, then pipes, so round-tripping is exact.
+     *   "Hall | Drama"  →  "Hall \| Drama"
+     *   "back\slash"    →  "back\\slash"
+     */
+    private String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("\\", "\\\\").replace("|", "\\|");
+    }
+
+    /**
+     * Reverses escape — unescape pipes first, then backslashes.
+     */
+    private String unescape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("\\|", "|").replace("\\\\", "\\");
+    }
+}


### PR DESCRIPTION
- Add StorageManager with save/load for 5 data files: ccas.txt, residents.txt, events.txt, memberships.txt, and event_attendance.txt
- Use pipe-delimited format with escape handling for special characters in field values
- Load order respects FK dependencies between files
- Corrupt or unresolvable rows are skipped with warnings rather than crashing the application
- Wire StorageManager into CcaLedger: load on startup, save after every mutating command
- Add isReadOnly() to Command base class; override in all view/stats/help commands to skip unnecessary saves
- Add findByName() to CcaManager, findByMatric() to ResidentManager, findByNameAndCca() to EventManager to support FK resolution during load