### PR TITLE
fix: validate points input in AddResidentToCcaCommand

### DIFF
--- a/src/main/java/ccamanager/command/AddResidentToCcaCommand.java
+++ b/src/main/java/ccamanager/command/AddResidentToCcaCommand.java
@@ -10,6 +10,7 @@ import ccamanager.model.Resident;
 import ccamanager.ui.Ui;
 
 import ccamanager.exceptions.CcaNotFoundException;
+import ccamanager.exceptions.InvalidPointsException;
 import ccamanager.exceptions.ResidentNotFoundException;
 import ccamanager.exceptions.ResidentAlreadyInCcaException;
 
@@ -20,14 +21,25 @@ public class AddResidentToCcaCommand extends Command {
     private final String ccaName;
     private final int pointsScored;
 
-    public AddResidentToCcaCommand(String matriculationNo, String ccaName, String pointsScored) {
+    public AddResidentToCcaCommand(String matriculationNo, String ccaName, String pointsScored)
+            throws InvalidPointsException {
         assert matriculationNo != null : "Matriculation number should not be null";
         assert ccaName != null : "CCA name should not be null";
         assert pointsScored != null : "Points scored should not be null";
-        assert Integer.parseInt(pointsScored) >= 0 : "Points scored must be greater than or equal to 0";
+        //assert Integer.parseInt(pointsScored) >= 0 : "Points scored must be greater than or equal to 0";
+
+        int parsedPoints;
+        try {
+            parsedPoints = Integer.parseInt(pointsScored);
+            if (parsedPoints < 0) {
+                throw new InvalidPointsException("Points scored must be non-negative, got: " + parsedPoints + ".");
+            }
+        } catch (NumberFormatException e) {
+            throw new InvalidPointsException("Points scored must be a valid integer, got: \"" + pointsScored + "\".");
+        }
         this.matriculationNo = matriculationNo;
         this.ccaName = ccaName;
-        this.pointsScored = Integer.parseInt(pointsScored);
+        this.pointsScored = parsedPoints;
     }
 
     @Override
@@ -54,6 +66,3 @@ public class AddResidentToCcaCommand extends Command {
         }
     }
 }
-
-
-

--- a/src/main/java/ccamanager/exceptions/InvalidPointsException.java
+++ b/src/main/java/ccamanager/exceptions/InvalidPointsException.java
@@ -1,0 +1,7 @@
+package ccamanager.exceptions;
+
+public class InvalidPointsException extends CcaLedgerException {
+    public InvalidPointsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ccamanager/parser/Parser.java
+++ b/src/main/java/ccamanager/parser/Parser.java
@@ -24,6 +24,8 @@ import ccamanager.command.SortPointsCommand;
 import ccamanager.command.UpdateCcaPointCommand;
 import ccamanager.enumerations.CcaLevel;
 
+import ccamanager.exceptions.InvalidPointsException;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -158,7 +160,11 @@ public class Parser {
             if (args[2].isBlank()) {
                 return new UnknownCommand("Points cannot be empty.");
             }
-            return new AddResidentToCcaCommand(args[0], args[1], args[2]);
+            try {
+                return new AddResidentToCcaCommand(args[0], args[1], args[2]);
+            } catch (InvalidPointsException e) {
+                return new UnknownCommand(e.getMessage());
+            }
 
         case "add-exco-to-cca":
             if (args.length < 2) {

--- a/src/test/java/ccamanager/command/AddResidentToCcaCommandTest.java
+++ b/src/test/java/ccamanager/command/AddResidentToCcaCommandTest.java
@@ -1,6 +1,7 @@
 package ccamanager.command;
 
 import ccamanager.enumerations.CcaLevel;
+import ccamanager.exceptions.InvalidPointsException;
 import ccamanager.manager.CcaManager;
 import ccamanager.manager.ResidentManager;
 import ccamanager.manager.EventManager;
@@ -8,7 +9,9 @@ import ccamanager.ui.Ui;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddResidentToCcaCommandTest {
 
@@ -29,8 +32,8 @@ public class AddResidentToCcaCommandTest {
     void execute_addResidentToCca_success() {
         new AddCcaCommand("Basketball", CcaLevel.HIGH).execute(ccaManager, residentManager, eventManager, ui);
         new AddResidentCommand("John", "A1234567B").execute(ccaManager, residentManager, eventManager, ui);
-        new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
-                .execute(ccaManager, residentManager, eventManager, ui);
+        assertDoesNotThrow(() -> new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
+                .execute(ccaManager, residentManager, eventManager, ui));
         assertEquals("Resident John | A1234567B was added to CCA: Basketball with 10 points.",
                 ui.getLastMessage());
     }
@@ -38,16 +41,16 @@ public class AddResidentToCcaCommandTest {
     @Test
     void execute_addResidentToCca_ccaNotFound() {
         new AddResidentCommand("John", "A1234567B").execute(ccaManager, residentManager, eventManager, ui);
-        new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
-                .execute(ccaManager, residentManager, eventManager, ui);
+        assertDoesNotThrow(() -> new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
+                .execute(ccaManager, residentManager, eventManager, ui));
         assertEquals("Basketball not found.", ui.getLastMessage());
     }
 
     @Test
     void execute_addResidentToCca_residentNotFound() {
         new AddCcaCommand("Basketball", CcaLevel.MEDIUM).execute(ccaManager, residentManager, eventManager, ui);
-        new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
-                .execute(ccaManager, residentManager, eventManager, ui);
+        assertDoesNotThrow(() -> new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
+                .execute(ccaManager, residentManager, eventManager, ui));
         assertEquals("A1234567B not found.", ui.getLastMessage());
     }
 
@@ -55,10 +58,29 @@ public class AddResidentToCcaCommandTest {
     void execute_addResidentToCca_alreadyInCca() {
         new AddCcaCommand("Basketball", CcaLevel.LOW).execute(ccaManager, residentManager, eventManager, ui);
         new AddResidentCommand("John", "A1234567B").execute(ccaManager, residentManager, eventManager, ui);
-        new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
-                .execute(ccaManager, residentManager, eventManager, ui);
-        new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
-                .execute(ccaManager, residentManager, eventManager, ui);
+        assertDoesNotThrow(() -> {
+            new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
+                    .execute(ccaManager, residentManager, eventManager, ui);
+            new AddResidentToCcaCommand("A1234567B", "Basketball", "10")
+                    .execute(ccaManager, residentManager, eventManager, ui);
+        });
         assertEquals("Resident John is already a member of Basketball.", ui.getLastMessage());
+    }
+
+    @Test
+    void constructor_negativePoints_throwsInvalidPointsException() {
+        assertThrows(InvalidPointsException.class,
+                () -> new AddResidentToCcaCommand("A1234567B", "Basketball", "-5"));
+    }
+
+    @Test
+    void constructor_nonIntegerPoints_throwsInvalidPointsException() {
+        assertThrows(InvalidPointsException.class,
+                () -> new AddResidentToCcaCommand("A1234567B", "Basketball", "abc"));
+    }
+
+    @Test
+    void constructor_zeroPoints_success() {
+        assertDoesNotThrow(() -> new AddResidentToCcaCommand("A1234567B", "Basketball", "0"));
     }
 }


### PR DESCRIPTION
- Replaced assert with a checked InvalidPointsException thrown in the constructor for invalid points input
- Handles both non-integer strings and negative values.
- Parser catches the exception and returns an UnknownCommand with the error message.
- Tests updated to reflect the checked exception and cover new validation cases.