### PR TITLE
fix: del static from membership lists in managers

### DIFF
--- a/src/main/java/ccamanager/manager/EventManager.java
+++ b/src/main/java/ccamanager/manager/EventManager.java
@@ -12,8 +12,8 @@ import java.util.logging.Logger;
 
 public class EventManager {
 
-    private static ArrayList<Event> events;
     private static final Logger logger = Logger.getLogger(EventManager.class.getName());
+    private final ArrayList<Event> events;
 
 
     public EventManager() {

--- a/src/main/java/ccamanager/manager/ResidentManager.java
+++ b/src/main/java/ccamanager/manager/ResidentManager.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
  */
 public class ResidentManager {
     private static final Logger logger = Logger.getLogger(ResidentManager.class.getName());
-    private static ArrayList<Resident> residents;
+    private final ArrayList<Resident> residents;
 
     public ResidentManager() {
         residents = new ArrayList<>();


### PR DESCRIPTION
Static fields caused all manager instances to share the same list, making in-session deletions inconsistent with post-restart state.
Removing static ensures each instance owns its list and mutations are reflected immediately in all views.